### PR TITLE
Corrige les vulnérabilités de dépendances et active Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ dist
 
 # Ignore IDE Folders
 .history
-.github
+.github/*
+!.github/dependabot.yml
 .vscode
 .idea
 
@@ -125,3 +126,6 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+# macOS
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -38,17 +38,17 @@
   "dependencies": {
     "eventing-bus": "^2.0.1",
     "lodash": "^4.17.20",
-    "rfxcom": "^2.3.1"
+    "rfxcom": "^2.6.2"
   },
   "devDependencies": {
-    "@types/node": "^14.14.6",
+    "@types/node": "^16.18.126",
     "@typescript-eslint/eslint-plugin": "^4.6.1",
     "@typescript-eslint/parser": "^4.6.1",
     "eslint": "^7.13.0",
     "homebridge": "^1.2.3",
-    "nodemon": "^2.0.6",
+    "nodemon": "^3.1.14",
     "rimraf": "^3.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "~5.6.0"
   }
 }


### PR DESCRIPTION
## Résumé

`npm audit` : **32 vulnérabilités (1 critique, 21 élevées) → 0**

## Le correctif principal : rfxcom 2.3.1 → 2.6.2

Le dépôt n'était **plus installable** : `serialport` 8 exige une compilation native qui échoue sur Node 18+ (`node-gyp` sur `@serialport/bindings`). `npm install` s'interrompait en erreur.

`rfxcom` 2.6.2 utilise `serialport` 11, qui s'appuie sur des binaires précompilés — plus aucune compilation nécessaire. C'est ce qui débloque à la fois l'installation et l'essentiel des alertes.

## Chaîne de build

`npm run build` était **déjà cassé avant ce correctif** :

```
node_modules/hap-nodejs/dist/lib/controller/CameraController.d.ts(241,61):
error TS2304: Cannot find name 'AbortSignal'.
```

`@types/node@14` est trop ancien pour `hap-nodejs`, qui référence `AbortSignal` (types Node 15+). Corrigé par `@types/node` 16, puis TypeScript 5.6 — TypeScript 4.0 ne sait pas parser ces définitions. La cible reste `ES2018`, aucun changement de code source.

`nodemon` 3 règle la dernière alerte (`semver` ReDoS via `simple-update-notifier`).

## Vérifications

- `npm install` : fonctionne à nouveau
- `npm run build` : OK (était en échec avant)
- `npm run lint` : OK
- `npm audit` : 0 vulnérabilité

## Divers

- `.github` était ignoré sous « IDE Folders » : remplacé par `.github/*` avec une exception pour `dependabot.yml`
- `.DS_Store` était indexé : retiré et ajouté au `.gitignore`